### PR TITLE
fix: add cppcheck suppressions file

### DIFF
--- a/.github/workflows/core_build_modules.yml
+++ b/.github/workflows/core_build_modules.yml
@@ -48,7 +48,7 @@ jobs:
         run: |
           sudo apt update -y
           sudo apt install -y cppcheck
-          cppcheck --force --inline-suppr modules/ --output-file=report.txt
+          cppcheck --force --inline-suppr --suppressions-list=cppchecksuppressions.txt modules/ --output-file=report.txt
           if [ -s report.txt ]; then
             cat report.txt
             exit 1

--- a/.github/workflows/core_build_modules.yml
+++ b/.github/workflows/core_build_modules.yml
@@ -48,7 +48,7 @@ jobs:
         run: |
           sudo apt update -y
           sudo apt install -y cppcheck
-          cppcheck --force --inline-suppr --suppressions-list=cppchecksuppressions.txt modules/ --output-file=report.txt
+          cppcheck --force --inline-suppr --suppressions-list=cppchecksuppressions.txt --output-file=report.txt modules/
           if [ -s report.txt ]; then
             cat report.txt
             exit 1

--- a/cppchecksuppressions.txt
+++ b/cppchecksuppressions.txt
@@ -1,1 +1,2 @@
 *:modules/mod-eluna/src/lualib/*
+*:modules/mod-eluna/src/LuaEngine/libs/*

--- a/cppchecksuppressions.txt
+++ b/cppchecksuppressions.txt
@@ -1,0 +1,1 @@
+*:modules/mod-eluna/src/lualib/*


### PR DESCRIPTION
We're getting false positives from `cppcheck` in `mod-eluna`, which makes the build workflow fail.

This PR adds a suppression file for Eluna's third party Lua lib, so that we don't have to modify these files in order to make the build pass. See page 18 of the [cppcheck manual](https://cppcheck.sourceforge.io/manual.pdf).

We can add exclusions in there for any module that needs it.
